### PR TITLE
Overlay now gets pointerEvents style set to 'none' to allow interaction ...

### DIFF
--- a/baseliner/baseliner.js
+++ b/baseliner/baseliner.js
@@ -81,6 +81,7 @@ var Baseliner = function(options) {
     this.overlay.style.top = this.opts.gridOffset + 'px';
     this.overlay.style.left = '0px';
     this.overlay.style.zIndex = 9998;
+    this.overlay.style.pointerEvents = 'none';
     this.overlay.style.opacity = this.opts.gridOpacity / 100;
     this.resize()
   }


### PR DESCRIPTION
...with underlying DOM

I was a bit annoyed with not being able to interact with underlying DOM when showing baseline so added this. I use this myself but thought I'd contribute to the main repo.
